### PR TITLE
Fix devEngines in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,8 +193,16 @@
     }
   },
   "devEngines": {
-    "node": ">=14.x",
-    "npm": ">=7.x"
+    "runtime": {
+      "name": "node",
+      "version": ">=14.x",
+      "onFail": "error"
+    },
+    "packageManager": {
+      "name": "npm",
+      "version": ">=7.x",
+      "onFail": "error"
+    }
   },
   "electronmon": {
     "patterns": [


### PR DESCRIPTION
This fixes compilation with newer node/npm versions. See https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/3648