### PR TITLE
Use 1-indexed split indices on modulation sliders

### DIFF
--- a/src/renderer/scenes/ModulationSlider.tsx
+++ b/src/renderer/scenes/ModulationSlider.tsx
@@ -40,7 +40,7 @@ export default function ModulationSlider({
 
   return (
     <Root ref={dragContainer} onMouseDown={onMouseDown}>
-      {`Split ${splitIndex} ${param}`}
+      {`Split ${splitIndex + 1} ${param}`}
       <Amount
         style={{
           left: `${left * 100}%`,


### PR DESCRIPTION
This fixes an inconsistency in the UI (note how the modal refers to the splits using 1-based indices and the modulation sliders use 0-based indices):

<img width="300" alt="Screenshot 2025-01-31 at 03 27 43" src="https://github.com/user-attachments/assets/291d9ec3-151c-43ef-ae7b-eaec84b75858" />
