### PR TITLE
Render subfixtures in the universe

### DIFF
--- a/src/renderer/dmx/FixtureCursor.tsx
+++ b/src/renderer/dmx/FixtureCursor.tsx
@@ -4,9 +4,11 @@ import { useDmxSelector } from '../redux/store'
 import Cursor from '../base/Cursor'
 import { setSelectedFixture } from '../redux/dmxSlice'
 import Window2D2 from '../base/Window2D2'
+import { window2DToParentCoords } from 'shared/window'
 
 export default function FixtureCursor({ index }: { index: number }) {
   const fixture = useDmxSelector((state) => state.universe[index])
+  const fixtureType = useDmxSelector((state) => state.fixtureTypesByID[fixture.type])
   const activeFixture = useDmxSelector((state) => state.activeFixture)
   const dispatch = useDispatch()
 
@@ -28,15 +30,26 @@ export default function FixtureCursor({ index }: { index: number }) {
     if (window.y !== undefined) y = window.y.pos
   }
 
-  return isSelected ? (
-    <div style={{ zIndex: -1 }}>
-      {/* <Cursor x={fixture.window?.x?.pos || 0.5} y={fixture.window?.y?.pos || 0.5} withHorizontal withVertical color="#fffc" />
-      <Window2D window2D={ fixture.window || {} }/> */}
-      <Window2D2 window2D={fixture.window} />
+  const subWindows = fixtureType.subFixtures
+    .map(sub => sub.relative_window ? window2DToParentCoords(sub.relative_window, fixture.window) : undefined)
+
+  return <div>
+    <div style={{ zIndex: -2 }}>
+      {subWindows.map(subWindow => subWindow ? (
+        <Cursor x={subWindow.x?.pos ?? x} y={subWindow.y?.pos ?? y} />
+      ) : undefined)}
     </div>
-  ) : (
-    <div style={{ zIndex: 1 }}>
-      <Cursor onClick={onClick} x={x} y={y} color="#fff7" />
-    </div>
-  )
+    {isSelected ? (
+      <div style={{ zIndex: -1 }}>
+        {/* <Cursor x={fixture.window?.x?.pos || 0.5} y={fixture.window?.y?.pos || 0.5} withHorizontal withVertical color="#fffc" />
+        <Window2D window2D={ fixture.window || {} }/> */}
+        <Window2D2 window2D={fixture.window} />
+      </div>
+    ) : (
+      <div style={{ zIndex: 1 }}>
+        <Cursor onClick={onClick} x={x} y={y} color="#fff7" />
+      </div>
+    )}
+  </div>
+
 }

--- a/src/shared/dmxUtil.ts
+++ b/src/shared/dmxUtil.ts
@@ -1,4 +1,4 @@
-import { Window, Window2D_t } from '../shared/window'
+import { Window, Window2D_t, window2DToParentCoords } from '../shared/window'
 import {
   DmxValue,
   DMX_MAX_VALUE,
@@ -291,7 +291,7 @@ export function flatten_fixture(
   let flattened: FlattenedFixture[] = fixture_type.subFixtures.map((sub) => {
     return {
       intensity: sub.intensity ?? fixture_type.intensity,
-      window: sub.relative_window ?? fixture.window,
+      window: sub.relative_window ? window2DToParentCoords(sub.relative_window, fixture.window) : fixture.window,
       channels: sub.channels.map((ch_index) => {
         subfixture_ch_indexes.add(ch_index)
         return [base_channel + ch_index, fixture_type.channels[ch_index]]

--- a/src/shared/window.ts
+++ b/src/shared/window.ts
@@ -9,3 +9,17 @@ export type Window2D_t = {
   x?: Window
   y?: Window
 }
+
+export function windowToParentCoords(relative: Window, parent: Window): Window {
+  return {
+    pos: parent.pos + relative.pos * parent.width,
+    width: relative.width * parent.width
+  }
+}
+
+export function window2DToParentCoords(relative: Window2D_t, parent: Window2D_t): Window2D_t {
+  return {
+    x: relative.x && parent.x ? windowToParentCoords(relative.x, parent.x) : undefined,
+    y: relative.y && parent.y ? windowToParentCoords(relative.y, parent.y) : undefined
+  }
+}

--- a/src/shared/window.ts
+++ b/src/shared/window.ts
@@ -12,7 +12,7 @@ export type Window2D_t = {
 
 export function windowToParentCoords(relative: Window, parent: Window): Window {
   return {
-    pos: parent.pos + relative.pos * parent.width,
+    pos: parent.pos + (relative.pos - 0.5) * parent.width,
     width: relative.width * parent.width
   }
 }


### PR DESCRIPTION
As a small addendum to #53, this renders the subfixtures (the parent fixture window is changed as usual with Cmd/Ctrl):

https://github.com/user-attachments/assets/9f1a2344-8eda-4340-957d-6b10bda2785b
