### PR TITLE
Fix DMX mixing regression

### DIFF
--- a/src/main/engine/dmxEngine.ts
+++ b/src/main/engine/dmxEngine.ts
@@ -45,7 +45,10 @@ export function calculateDmx(
       // Set each channel based on active scene fixtures
       forEachChannel(splitSceneFixtures, (fixtureIdx, fixture, channelIdx, channel) => {
         const randomizerLevel = randomizer[fixtureIdx]?.level ?? 1
-        channels[channelIdx] = getDmxValue(channel, outputParams, fixture, state.control.master, randomizerLevel)
+        channels[channelIdx] = Math.max(
+          channels[channelIdx],
+          getDmxValue(channel, outputParams, fixture, state.control.master, randomizerLevel)
+        )
       })
     }
 


### PR DESCRIPTION
### Fixes #60 

This fixes the mixing regression introduced in https://github.com/spensbot/captivate/commit/abb831c4978be7b8195f9eb26fe167e8618b4cf9, every fixture overwrites the existing channel value, which caused split colors to not be mixed properly. With this patch, updates to the DMX channel values are now combined with `max`.

Might be worth taking a look at the intensity parameter too, which was removed in that commit, not sure if that's relevant, since it doesn't seem to be supported by the fixtures I tested this with.